### PR TITLE
Address issue #2

### DIFF
--- a/ebutt_datatypes.xsd
+++ b/ebutt_datatypes.xsd
@@ -53,7 +53,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="distributionMediaTimingType">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-9][0-9][0-9]*:[0-5][0-9]:([0-5][0-9]|[0-6][0])((\.[0-9][0-9][0-9])+)?"/>
+			<xs:pattern value="[0-9][0-9]+:[0-5][0-9]:([0-5][0-9]|[0-6][0])(\.[0-9]+)?"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="distributionLengthType">


### PR DESCRIPTION
Modify regex for media timing type matching to permit any number >1 of decimal places. Also tweak hours component to be more concise - `[0-9][0-9]*` is equivalent to `[0-9]+`.
