### PR TITLE
Fix cell resolution type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 The publication of the EBU-TT-D XML Schema for EBU-TT-D is intended to support the implementation of the specification in EBU-Tech 3380 version 1.0.
 
-The current version of the EBU-TT-D XML Schema is 1.0.
+The current version of the EBU-TT-D XML Schema is 1.0.1.
 
 Please note that the EBU-TT-D XML Schema is a helping document and NOT normative but informative.
 
@@ -11,7 +11,7 @@ To validate an XML document choose ebutt_d.xsd. This XML Schema file imports the
 If you have any question regarding the use of the XML Schema please contact subtitling@ebu.ch or tai@irt.de.
 
 ## Contributors
-Andreas Tai (IRT), Barbara Fichte (IRT), Gary Pearman, Nigel Megitt (BBC)
+Andreas Tai (IRT), Barbara Fichte (IRT), Gary Pearman, Nigel Megitt (BBC), Zoltan Kozma
 
 ## Acknowledgement
 Parts of the the EBU-TT-D W3C XML Schema were developed in the European collaborative research project HBB4ALL. This project has received funding from the European Union ICT Policy Support Programme (ICT PSP) under the Competitiveness and Innovation Framework Programme (CIP).

--- a/ebutt_datatypes.xsd
+++ b/ebutt_datatypes.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ebuttdt="urn:ebu:tt:datatypes" targetNamespace="urn:ebu:tt:datatypes">
 	<xs:simpleType name="cellResolutionType">
 		<xs:restriction base="xs:token">
-			<xs:pattern value="[1-9][0-9]*\s[1-9][0-9]*"/>
+			<xs:pattern value="[0]*[1-9][0-9]*\s[0]*[1-9][0-9]*"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="framerateMultiplierType">


### PR DESCRIPTION
- The cell resolution type must allow leading zeros.

- The fix is based on the proposal by Zoltan Kozma.

- This fixes #7.