### PR TITLE
Metadata not allowed on style

### DIFF
--- a/ebutt_d.xsd
+++ b/ebutt_d.xsd
@@ -4,7 +4,8 @@
 	xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
 	xmlns:ebuttm="urn:ebu:tt:metadata" xmlns:ebutts="urn:ebu:tt:style"
 	targetNamespace="http://www.w3.org/ns/ttml">
-	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<xs:import namespace="http://www.w3.org/XML/1998/namespace"
+		schemaLocation="http://www.w3.org/2001/xml.xsd"/>
 	<xs:import namespace="http://www.w3.org/ns/ttml#styling" schemaLocation="styling.xsd"/>
 	<xs:import namespace="http://www.w3.org/ns/ttml#parameter" schemaLocation="parameter.xsd"/>
 	<xs:import namespace="urn:ebu:tt:metadata" schemaLocation="ebutt_metadata.xsd"/>
@@ -82,9 +83,6 @@
 			<xs:documentation>Set of style information.</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="tt:metadata" minOccurs="0"/>
-			</xs:sequence>
 			<xs:attribute ref="xml:id" use="required">
 				<xs:annotation>
 					<xs:documentation>ID of a tt:style element that is used by other elements for


### PR DESCRIPTION
- TTML does not allow a tt:metadata child under tt:style.

- This closes #9.