### PR TITLE
Updates to include Tech3390 metadata

### DIFF
--- a/ebutt_datatypes.xsd
+++ b/ebutt_datatypes.xsd
@@ -18,6 +18,23 @@
 	<xs:simpleType name="fontFamilyType">
 		<xs:union memberTypes="ebuttdt:genericFamilyName ebuttdt:familyName"/>
 	</xs:simpleType>
+	<xs:simpleType name="fontSizeType">
+		<xs:union
+			memberTypes="ebuttdt:distributionLengthType"
+		/>
+	</xs:simpleType>
+	<xs:simpleType name="fontStyleType">
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="normal"/>
+			<xs:enumeration value="italic"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="fontWeightType">
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="normal"/>
+			<xs:enumeration value="bold"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:simpleType name="distributionFontSizeType">
 		<xs:restriction base="ebuttdt:distributionLengthType"/>
 	</xs:simpleType>
@@ -85,6 +102,26 @@
 	</xs:simpleType>
 	<xs:simpleType name="familyName">
 		<xs:restriction base="xs:string">
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="noTimezoneDateType">
+		<xs:restriction base="xs:date">
+			<xs:pattern value="[^:Z]*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="transitionStyleAttributeType">
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="block"/>
+			<xs:enumeration value="line"/>
+			<xs:enumeration value="word"/>
+			<xs:enumeration value="partOfWord"/>
+			<xs:enumeration value="groupOfWords"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:simpleType name="authoringDelayType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[+-]?[0-9]+(\.[0-9]+)?(h|ms|s|m)"/>
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/ebutt_metadata.xsd
+++ b/ebutt_metadata.xsd
@@ -1,166 +1,833 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:ebu:tt:metadata" xmlns:ebuttm="urn:ebu:tt:metadata" xmlns:ebuttdt="urn:ebu:tt:datatypes" targetNamespace="urn:ebu:tt:metadata" elementFormDefault="qualified">
-	<xs:import namespace="urn:ebu:tt:datatypes" schemaLocation="ebutt_datatypes.xsd"/>
-	<xs:element name="documentMetadata">
+<!-- Copyright 2019, EBU, www.ebu.ch -->
+<!-- Version of XML Schema: 0.9 -->
+<!-- Creation: 07/02/2019 -->
+<!--  The publication of this XML Schema is intended to support the implementation of the EBU Tech3390 v1.0 specification.
+Please note that the EBU-TT XML Schema is a helping document and NOT normative but informative.-->
+
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns="urn:ebu:tt:metadata" xmlns:ebuttm="urn:ebu:tt:metadata"
+	xmlns:ebuttdt="urn:ebu:tt:datatypes"
+	xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+	targetNamespace="urn:ebu:tt:metadata" elementFormDefault="qualified"
+	xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+	<xs:import namespace="urn:ebu:tt:datatypes"
+		schemaLocation="ebutt_datatypes.xsd"/>
+	<xs:import namespace="http://www.w3.org/ns/ttml#metadata"
+		schemaLocation="metadata.xsd"/>
+	<xs:complexType name="binaryData_type">
 		<xs:annotation>
-			<xs:documentation>EBU-TT-D specific metadata that applies to the whole EBU-TT-D document.</xs:documentation>
+			<xs:documentation>Binary data of the input formats or associated
+				documents used to generate an EBU-TT-D
+				document.</xs:documentation>
 		</xs:annotation>
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="conformsToStandard" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="textEncoding" use="required">
 					<xs:annotation>
-						<xs:documentation>Indicates the conformance with a specific standard that is derived from TTML. For EBU-TT-D the following URI shall be used: “urn:ebu:tt:distribution:2014-01”</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="authoredFrameRate" type="xs:positiveInteger" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>The ebuttm:authoredFrameRate element is used to specify the frame rate that was assumed (or measured) by the author of the document for the related media object when the EBU-TT-D document was created.</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="authoredFrameRateMultiplier" type="ebuttdt:framerateMultiplierType" minOccurs="0" maxOccurs="unbounded">
-					<xs:annotation>
-						<xs:documentation>The ebuttm:authoredFrameRate element is used to specify the frame rate that was assumed (or measured) by the author of the document for the related media object when the EBU-TT-D document was created.</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentEbuttVersion" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>The version of the EBU-TT-D standard used by the document instance.</xs:documentation>
+						<xs:documentation>Text encoding of the binary
+							data.</xs:documentation>
 					</xs:annotation>
 					<xs:simpleType>
-						<xs:restriction base="xs:token">
-							<xs:enumeration value="v1.0"/>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="BASE64"/>
 						</xs:restriction>
 					</xs:simpleType>
-				</xs:element>
-				<xs:element name="documentIdentifier" type="xs:string" minOccurs="0">
+				</xs:attribute>
+				<xs:attribute name="binaryDataType" type="xs:string"
+					use="required">
 					<xs:annotation>
-						<xs:documentation>Identifier for an EBU-TT-D document that may be used as external reference to an EBU-TT-D document.</xs:documentation>
+						<xs:documentation>Internal format of the binary
+							data.</xs:documentation>
 					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentOriginatingSystem" type="xs:string" minOccurs="0">
+				</xs:attribute>
+				<xs:attribute name="fileName" type="xs:string">
 					<xs:annotation>
-						<xs:documentation>Software and version used to create the EBU-TT-D document.</xs:documentation>
+						<xs:documentation>A filename that may be used to
+							identify the original filename of the tunnelled
+							binary data.</xs:documentation>
 					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentTargetAspectRatio" type="xs:string" minOccurs="0">
+				</xs:attribute>
+				<xs:attribute name="creationDate" type="xs:date">
 					<xs:annotation>
-						<xs:documentation>The aspect ratio of the video the EBU-TT-D document was authored for, in width by height.</xs:documentation>
+						<xs:documentation/>
 					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentTargetActiveFormatDescriptor" type="xs:string" minOccurs="0">
+				</xs:attribute>
+				<xs:attribute name="revisionDate" type="xs:date">
 					<xs:annotation>
-						<xs:documentation>The code for the Active Format Descriptor (AFD) that specifies the active image in the active video (see “Definitions of terms”). The code shall be one of the AFD codes specified in SMPTE ST 2016 1:2009 “Format for Active Format Description and Bar Data” Table 1.</xs:documentation>
+						<xs:documentation/>
 					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentIntendedTargetBarData" minOccurs="0">
+				</xs:attribute>
+				<xs:attribute name="revisionNumber" type="xs:nonNegativeInteger">
 					<xs:annotation>
-						<xs:documentation>When an ebuttm:documentTargetActiveFormatDescriptor element is used in an EBU-TT-D document, an ebuttm:documentIntendedTargetBarData element may be used whenever the AFD alone is insufficient to describe the extent of the image (i.e. AFD values 0000 and 0100). The Bar Data shall be specified in accordance with SMPTE ST 2016 1:2009 “Format for Active Format Description and Bar Data” Table 3.</xs:documentation>
+						<xs:documentation/>
 					</xs:annotation>
-					<xs:complexType>
-						<xs:simpleContent>
-							<xs:extension base="xs:string">
-								<xs:attribute name="position" use="required">
-									<xs:annotation>
-										<xs:documentation>Bar Data is defined in pairs, either top and bottom bars or left and right bars, but not both pairs at once. Bars may be unequal in size. One bar of a pair may be zero width or height.</xs:documentation>
-									</xs:annotation>
-									<xs:simpleType>
-										<xs:restriction base="xs:string">
-											<xs:enumeration value="topBottom"/>
-											<xs:enumeration value="leftRight"/>
-										</xs:restriction>
-									</xs:simpleType>
-								</xs:attribute>
-								<xs:attribute name="lineNumberEndOfTopBar" type="xs:nonNegativeInteger">
-									<xs:annotation>
-										<xs:documentation>Last line of a horizontal letter box bar area at the top of the reconstructed frame. Designation of line numbers shall be based on the video standards and information specified in accordance with SMPTE ST 2016 1:2009. All Bar Data values shall be stated in values appropriate to a progressive frame system.</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-								<xs:attribute name="lineNumberStartOfBottomBar" type="xs:nonNegativeInteger">
-									<xs:annotation>
-										<xs:documentation>First line of a horizontal letter box bar area at the bottom of the reconstructed frame. Designation of line numbers shall be based on the video standards and information specified in accordance with SMPTE ST 2016 1:2009. All Bar Data values shall be stated in values appropriate to a progressive frame system.</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-								<xs:attribute name="pixelNumberEndOfLeftBar" type="xs:nonNegativeInteger">
-									<xs:annotation>
-										<xs:documentation>Last horizontal luminance sample of a vertical pillar box bar area at the left side of the reconstructed frame. Pixels shall be numbered from zero, starting with the leftmost pixel, based on the video standards and information specified in accordance with SMPTE ST 2016 1:2009.</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-								<xs:attribute name="pixelNumberStartOfRightBar" type="xs:nonNegativeInteger">
-									<xs:annotation>
-										<xs:documentation>First horizontal luminance sample of a vertical pillar box bar area at the right side of the reconstructed frame. Pixels shall be numbered from zero, starting with the leftmost pixel, based on the video standards and information specified in accordance with SMPTE ST 2016 1:2009.</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-							</xs:extension>
-						</xs:simpleContent>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="documentIntendedTargetFormat" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Indicates the subtitle format an author had in mind when authoring an EBU-TT-D document or transforming another format to an EBU-TT-D document.</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:simpleContent>
-							<xs:extension base="xs:string">
-								<xs:attribute name="link" type="xs:anyURI">
-									<xs:annotation>
-										<xs:documentation>Reference to a term in a classification scheme.</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-							</xs:extension>
-						</xs:simpleContent>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="documentTranslatorsName" type="xs:string" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Name of the translator. STL mapping: Translator's Name (TN). </xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentTranslatorsContactDetails" type="xs:string" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>The translator's contact details. STL mapping: Translator's Contact Details (TCD).</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentCreationDate" type="xs:date" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>The date of creation of the EBU-TT-D document. STL mapping: Creation Date (CD). </xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentRevisionDate" type="xs:date" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>The date of the most-recent modifications to the EBU-TT-D document. STL mapping: Revision Date (RD). </xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentRevisionNumber" type="xs:nonNegativeInteger" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>The revision number of the EBU-TT-D document may be used to specify a particular version of the subtitle list. STL mapping:  Revision Number (RN).</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentCountryOfOrigin" type="xs:string" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>The country of origin of the subtitle list. STL mapping: Country of Origin (CO). </xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentPublisher" type="xs:string" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Name of the publisher of the subtitle list. STL mapping: Publisher (PUB).</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentEditorsName" type="xs:string" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Name of the editor of the subtitle list. STL mapping: Editor's Name (EN).</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentEditorsContactDetails" type="xs:string" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Information about the editor named in the metadata element documentEditorsName. STL mapping: Editor's Contact Details (ECD). </xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="documentUserDefinedArea" type="xs:string" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>This field may be used to carry information about the programme or subtitle list, or other relevant details. STL mapping: User-Defined Area (UDA).</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-			</xs:sequence>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+
+	</xs:complexType>
+
+
+	<xs:element name="conformsToStandard" type="xs:anyURI">
+		<xs:annotation>
+			<xs:documentation>Indicates the conformance with a specific
+				standard that is derived from TTML.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentEbuttVersion">
+		<xs:annotation>
+			<xs:documentation>The version of the EBU-TT standard used by
+				the document instance. Deprecated, Use conformsToStandard
+				instead.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleType>
+			<xs:restriction base="xs:token">
+				<xs:enumeration value="v1.0"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:element>
+	<xs:element name="documentIdentifier" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Identifier for an EBU-TT document that may
+				be used as external reference to an EBU-TT
+				document.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentOriginatingSystem" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Software and version used to create the
+				EBU-TT document.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentCopyright" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The copyright of the
+				document. Deprecated. Use ttm:copyright instead.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentReadingSpeed" type="xs:positiveInteger">
+		<xs:annotation>
+			<xs:documentation>The intended reading speed for the
+				subtitles in words per minute.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentTargetAspectRatio" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The aspect ratio of the video the EBU-TT
+				document was authored for, in width by
+				height.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentTargetActiveFormatDescriptor"
+		type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The code for the Active Format Descriptor
+				(AFD) that specifies the active image in the active
+				video (see “Definitions of terms”). The code shall be
+				one of the AFD codes specified in SMPTE ST 2016 1:2009
+				“Format for Active Format Description and Bar Data”
+				Table 1.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentIntendedTargetBarData">
+		<xs:annotation>
+			<xs:documentation>When an
+				ebuttm:documentTargetActiveFormatDescriptor element is
+				used in an EBU-TT document, an
+				ebuttm:documentIntendedTargetBarData element may be used
+				whenever the AFD alone is insufficient to describe the
+				extent of the image (i.e. AFD values 0000 and 0100). The
+				Bar Data shall be specified in accordance with SMPTE ST
+				2016 1:2009 “Format for Active Format Description and
+				Bar Data” Table 3.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:string">
+					<xs:attribute name="position" use="required">
+						<xs:annotation>
+							<xs:documentation>Bar Data is defined in
+								pairs, either top and bottom bars or
+								left and right bars, but not both pairs
+								at once. Bars may be unequal in size.
+								One bar of a pair may be zero width or
+								height.</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="topBottom"/>
+								<xs:enumeration value="leftRight"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="lineNumberEndOfTopBar"
+						type="xs:nonNegativeInteger">
+						<xs:annotation>
+							<xs:documentation>Last line of a horizontal
+								letter box bar area at the top of the
+								reconstructed frame. Designation of line
+								numbers shall be based on the video
+								standards and information specified in
+								accordance with SMPTE ST 2016 1:2009.
+								All Bar Data values shall be stated in
+								values appropriate to a progressive
+								frame system.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="lineNumberStartOfBottomBar"
+						type="xs:nonNegativeInteger">
+						<xs:annotation>
+							<xs:documentation>First line of a horizontal
+								letter box bar area at the bottom of the
+								reconstructed frame. Designation of line
+								numbers shall be based on the video
+								standards and information specified in
+								accordance with SMPTE ST 2016 1:2009.
+								All Bar Data values shall be stated in
+								values appropriate to a progressive
+								frame system.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="pixelNumberEndOfLeftBar"
+						type="xs:nonNegativeInteger">
+						<xs:annotation>
+							<xs:documentation>Last horizontal luminance
+								sample of a vertical pillar box bar area
+								at the left side of the reconstructed
+								frame. Pixels shall be numbered from
+								zero, starting with the leftmost pixel,
+								based on the video standards and
+								information specified in accordance with
+								SMPTE ST 2016 1:2009.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="pixelNumberStartOfRightBar"
+						type="xs:nonNegativeInteger">
+						<xs:annotation>
+							<xs:documentation>First horizontal luminance
+								sample of a vertical pillar box bar area
+								at the right side of the reconstructed
+								frame. Pixels shall be numbered from
+								zero, starting with the leftmost pixel,
+								based on the video standards and
+								information specified in accordance with
+								SMPTE ST 2016 1:2009.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="documentIntendedTargetFormat">
+		<xs:annotation>
+			<xs:documentation>Indicates the subtitle format an author
+				had in mind when authoring an EBU-TT document or
+				transforming another format to an EBU-TT
+				document.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:string">
+					<xs:attribute name="link" type="xs:anyURI">
+						<xs:annotation>
+							<xs:documentation>Reference to a term in a
+								classification
+								scheme.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="documentCreationMode">
+		<xs:annotation>
+			<xs:documentation>Identifies the overall workflow used to
+				create the content in the document.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleType>
+			<xs:restriction base="xs:string">
+				<xs:enumeration value="live"/>
+				<xs:enumeration value="prepared"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:element>
+	<xs:element name="documentContentType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:string">
+					<xs:attribute name="link" type="xs:anyURI">
+						<xs:annotation>
+							<xs:documentation>Reference to a term in a
+								classification scheme.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="sourceMediaIdentifier"
+		type="ebuttm:sourceMediaIdentifier_type"/>
+	<xs:element name="relatedMediaIdentifier" type="xs:string"/>
+	<xs:element name="relatedObjectIdentifier">
+		<xs:complexType>
+			<xs:attribute name="type" type="xs:string"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="relatedMediaDuration"
+		type="ebuttdt:distributionMediaTimingType"/>
+	<xs:element name="documentBeginDate"
+		type="ebuttdt:noTimezoneDateType"/>
+	<xs:element name="localTimeOffset" type="xs:string"/>
+	<xs:element name="referenceClockIdentifier" type="xs:string"/>
+	<xs:element name="broadcastServiceIdentifier">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:string">
+					<xs:attribute name="serviceBegin" type="xs:dateTime"
+						use="required"/>
+					<xs:attribute name="serviceEnd" type="xs:dateTime"
+						use="required"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="documentTransitionStyle"
+		type="ebuttm:documentTransitionStyle_type"/>
+	<xs:element name="documentOriginalProgrammeTitle" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The programme title in the original
+				language. STL mapping: Original Programme Title
+				(OPT).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentOriginalEpisodeTitle" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The title of the episode of the programme
+				in the original language. STL mapping: Original Episode
+				Title (OET).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentTranslatedProgrammeTitle" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The programme title in the local language.
+				STL mapping: Translated Programme Title
+				(TPT).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentTranslatedEpisodeTitle" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The title of the episode of the programme
+				in the local language. STL mapping: Translated Episode
+				Title (TET).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentTranslatorsName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Name of the translator. STL mapping:
+				Translator's Name (TN). </xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentTranslatorsContactDetails"
+		type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The translator's contact details. STL
+				mapping: Translator's Contact Details
+				(TCD).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentSubtitleListReferenceCode"
+		type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Free-format character string which may be
+				used to provide an additional reference for the subtitle
+				list. Note: This attribute is provided to support
+				conversion of STL subtitle files and to retain the
+				metadata from the GSI block. STL mapping: Subtitle List
+				Reference Code (SLR)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentCreationDate" type="xs:date">
+		<xs:annotation>
+			<xs:documentation>The date of creation of the EBU-TT
+				document. </xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentRevisionDate" type="xs:date" >
+		<xs:annotation>
+			<xs:documentation>The date of the most-recent modifications
+				to the EBU-TT document. </xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentRevisionNumber"
+		type="xs:nonNegativeInteger" >
+		<xs:annotation>
+			<xs:documentation>The revision number of the EBU-TT document
+				may be used to specify a particular version of the
+				subtitle list. </xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentTotalNumberOfSubtitles"
+		type="xs:nonNegativeInteger">
+		<xs:annotation>
+			<xs:documentation>The number of subtitles. STL mapping:
+				Total Number of Subtitles (TNS).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element
+		name="documentMaximumNumberOfDisplayableCharacterInAnyRow"
+		type="xs:nonNegativeInteger">
+		<xs:annotation>
+			<xs:documentation>Maximum number of displayable rows per
+				television frame which could be occupied at any one time
+				by the subtitles defined in the TTI blocks. STL mapping:
+				Maximum Number of Displayable Characters in any text row
+				(MNC). </xs:documentation>
+		</xs:annotation>
+	</xs:element>
+<!--	<xs:element name="documentStartOfProgramme"	type="ebuttdt:smpteTimingType">
+		<xs:annotation>
+			<xs:documentation>The time code of the first frame of the
+				recorded video signal which is intended for
+				transmission. Note: When the referenced start timecode
+				of the video material the subtitles were authored for is
+				greater than 00:00:00:00 (e.g. 10:00:00:00) it is
+				recommended to specify the attribute
+				ebuttm:documentStartOfPrograme. STL mapping: Timecode:
+				Start-of-Programme (TCP).
+				
+				Since this element requires a smpteTimingType value, 
+				which carries no useful meaning in EBU-TT-D, the element
+				definition is commented out in this XSD despite being
+				present in EBU Tech3390.
+				</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+-->	<xs:element name="documentCountryOfOrigin" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>The country of origin of the subtitle
+				list. STL mapping: Country of Origin (CO).
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentPublisher" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Name of the publisher of the subtitle
+				list. STL mapping: Publisher (PUB).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentEditorsName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Name of the editor of the subtitle list.
+				STL mapping: Editor's Name (EN).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentEditorsContactDetails" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Information about the editor named in the
+				metadata element documentEditorsName. STL mapping:
+				Editor's Contact Details (ECD). </xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentUserDefinedArea" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>This field may be used to carry
+				information about the programme or subtitle list, or
+				other relevant details. STL mapping: User-Defined Area
+				(UDA).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="stlCreationDate" type="xs:date">
+		<xs:annotation>
+			<xs:documentation/>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="stlRevisionDate" type="xs:date">
+		<xs:annotation>
+			<xs:documentation/>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="stlRevisionNumber" type="xs:nonNegativeInteger">
+		<xs:annotation>
+			<xs:documentation/>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="subtitleZero" type="xs:string"/>
+	<xs:element name="originalSourceServiceIdentifier" type="xs:string">
+		<xs:annotation>
+			<xs:documentation> The
+				ebuttm:originalSourceServiceIdentifier may be used to
+				identify the stream of audio-visual content that was
+				used as the source for authoring the document.
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="intendedDestinationServiceIdentifier"	type="xs:string">
+		<xs:annotation>
+			<xs:documentation> The
+				ebuttm:intendedDestinationServiceIdentifier may be used
+				to identify the streams of destination audio-visual
+				content for which the document is intended to apply.
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="documentFacet" type="ebuttm:documentFacet_type"/>
+	<xs:element name="appliedProcessing" type="ebuttm:appliedProcessing_type" />
+	<xs:element name="stlConversion" type="ebuttm:stlConversion_type"/>
+
+	<xs:group name="ebu-tt-metadata.class">
+		<xs:choice>
+			<xs:element ref="conformsToStandard"/>
+			<xs:element ref="documentEbuttVersion"/>
+			<xs:element ref="documentIdentifier"/>
+			<xs:element ref="documentOriginatingSystem"/>
+			<xs:element ref="documentCopyright"/>
+			<xs:element ref="documentReadingSpeed"/>
+			<xs:element ref="documentTargetAspectRatio"/>
+			<xs:element ref="documentTargetActiveFormatDescriptor"/>
+			<xs:element ref="documentIntendedTargetBarData"/>
+			<xs:element ref="documentIntendedTargetFormat"/>
+			<xs:element ref="documentCreationMode"/>
+			<xs:element ref="documentContentType"/>
+			<xs:element ref="sourceMediaIdentifier"/>
+			<xs:element ref="relatedMediaIdentifier"/>
+			<xs:element ref="relatedObjectIdentifier"/>
+			<xs:element ref="relatedMediaDuration"/>
+			<xs:element ref="documentBeginDate"/>
+			<xs:element ref="localTimeOffset"/>
+			<xs:element ref="referenceClockIdentifier"/>
+			<xs:element ref="broadcastServiceIdentifier"/>
+			<xs:element ref="documentTransitionStyle"/>
+			<xs:element ref="documentOriginalProgrammeTitle"/>
+			<xs:element ref="documentOriginalEpisodeTitle"/>
+			<xs:element ref="documentTranslatedProgrammeTitle"/>
+			<xs:element ref="documentTranslatedEpisodeTitle"/>
+			<xs:element ref="documentTranslatorsName"/>
+			<xs:element ref="documentTranslatorsContactDetails"/>
+			<xs:element ref="documentSubtitleListReferenceCode"/>
+			<xs:element ref="documentCreationDate"/>
+			<xs:element ref="documentRevisionDate"/>
+			<xs:element ref="documentRevisionNumber"/>
+			<xs:element ref="documentTotalNumberOfSubtitles"/>
+			<xs:element ref="documentMaximumNumberOfDisplayableCharacterInAnyRow"/>
+<!--			<xs:element ref="documentStartOfProgramme"/>-->
+			<xs:element ref="documentCountryOfOrigin"/>
+			<xs:element ref="documentPublisher"/>
+			<xs:element ref="documentEditorsName"/>
+			<xs:element ref="documentEditorsContactDetails"/>
+			<xs:element ref="documentUserDefinedArea"/>
+			<xs:element ref="stlCreationDate"/>
+			<xs:element ref="stlRevisionDate"/>
+			<xs:element ref="stlRevisionNumber"/>
+			<xs:element ref="subtitleZero"/>
+			<xs:element ref="originalSourceServiceIdentifier"/>
+			<xs:element ref="intendedDestinationServiceIdentifier"/>
+			<xs:element ref="documentFacet"/>
+			<xs:element ref="appliedProcessing"/>
+			<xs:element ref="stlConversion"/>
+		</xs:choice>
+	</xs:group>
+	
+	<xs:complexType name="documentMetadata">
+		<xs:annotation>
+			<xs:documentation>EBU-TT specific metadata that applies to the whole
+				EBU-TT document.</xs:documentation>
+		</xs:annotation>
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:group ref="ebu-tt-metadata.class"/>
+		</xs:choice>
+	</xs:complexType>
+
+
+	<xs:complexType name="appliedProcessing_type">
+		<xs:sequence>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0"
+				maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="process" type="xs:string" use="required"/>
+		<xs:attribute name="generatedBy" type="xs:anyURI" use="required"/>
+		<xs:attribute name="sourceId" type="xs:anyURI" use="optional"/>
+		<xs:attribute name="appliedDateTime" type="xs:dateTime"/>
+	</xs:complexType>
+
+	<xs:complexType name="stlConversionParameter_type">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="key" type="xs:string" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="stlConversion_type" mixed="false">
+		<xs:sequence>
+			<xs:element name="stlParameter" minOccurs="0" maxOccurs="unbounded"
+				type="stlConversionParameter_type"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="facet_type">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional"/>
+				<xs:attribute name="expresses" use="optional">
+					<xs:simpleType>
+						<xs:restriction base="xs:token">
+							<xs:enumeration value="has"/>
+							<xs:enumeration value="unknown"/>
+							<xs:enumeration value="has_not"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="documentFacet_type">
+		<xs:annotation>
+			<xs:documentation> The documentFacet element indicates a document
+				level summary of a facet that applies to the document's content
+				as defined by the facet element. The value may be the name of a
+				term in a classification scheme, whose term should be identified
+				by the link attribute. Each distinctly identified facet that is
+				summarised shall have a separate documentFacet element. Empty
+				documentFacet elements should have a link attribute. Documents
+				shall NOT contain more than one documentFacet element referring
+				to the same term, where the term is identified by the
+				combination of the element contents and the value of the link
+				attribute. </xs:documentation>
+		</xs:annotation>
+
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI" use="optional"/>
+				<xs:attribute name="summary" use="optional">
+					<xs:simpleType>
+						<xs:restriction base="xs:token">
+							<xs:enumeration value="all_has"/>
+							<xs:enumeration value="mixed"/>
+							<xs:enumeration value="all_has_not"/>
+							<xs:enumeration value="unspecified"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+
+	</xs:complexType>
+
+
+
+	<xs:complexType name="font_type">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="fontFamilyName"
+					type="ebuttdt:fontFamilyType" use="required"/>
+				<xs:attribute name="src" type="xs:anyURI" use="required"/>
+				<xs:attribute name="fontStyle" type="ebuttdt:fontStyleType"
+					use="optional"/>
+				<xs:attribute name="fontWeight" type="ebuttdt:fontWeightType"
+					use="optional"/>
+				<xs:attribute name="fontSize" type="ebuttdt:distributionFontSizeType"
+					use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="authoringTechnique_type">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="link" type="xs:anyURI">
+					<xs:annotation>
+						<xs:documentation>Reference to a term in a
+							classification scheme.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:attribute name="authoringDelay" type="ebuttdt:authoringDelayType">
+		<xs:annotation>
+			<xs:documentation> The authoring delay associated with the timed
+				content within this document may be indicated using the
+				ebuttm:authoringDelay attribute. NOTE: This delay may be
+				estimated or measured, and is intended to represent the duration
+				between when the subitle authoring tool received the
+				instantaneous media for which subtitles were authored and the
+				moment that the authoring tool emitted those subtitles.
+			</xs:documentation>
+		</xs:annotation>
+	</xs:attribute>
+
+	<xs:attribute name="authorsGroupSelectedSequenceIdentifier">
+		<xs:annotation>
+			<xs:documentation> The selected sequenceIdentifier is to be moved
+				here by the handover node. </xs:documentation>
+		</xs:annotation>
+		<xs:simpleType>
+			<xs:restriction base="xs:string">
+				<xs:minLength value="1"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:attribute>
+
+	<xs:complexType name="sourceMediaIdentifier_type">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="type" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="documentTransitionStyle_type">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="inUnit"
+					type="ebuttdt:transitionStyleAttributeType" use="required"/>
+				<xs:attribute name="outUnit"
+					type="ebuttdt:transitionStyleAttributeType" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="anyMetadata_type">
+		<xs:annotation>
+			<xs:documentation>Container for metadata
+				information.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:any namespace="not http://www.w3.org/ns/ttml urn:ebu:tt"
+				minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="metadataBase_type">
+		<xs:sequence>
+			<xs:element ref="ttm:title" minOccurs="0"/>
+			<xs:element ref="ttm:desc" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="headMetadata_type">
+		<xs:complexContent>
+			<xs:extension base="ebuttm:metadataBase_type">
+				<xs:sequence>
+					<xs:choice>
+						<xs:choice minOccurs="1" maxOccurs="unbounded">
+							<xs:group ref="ebu-tt-metadata.class"/>
+						</xs:choice>
+						<xs:element name="documentMetadata"
+							type="ebuttm:documentMetadata">
+							<xs:unique name="unique-documentFacet">
+								<xs:selector xpath="ebuttm:documentFacet"/>
+								<xs:field xpath="."/>
+							</xs:unique>
+						</xs:element>
+					</xs:choice>
+					<xs:element ref="ttm:agent" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:element name="binaryData" type="binaryData_type"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:any minOccurs="0" maxOccurs="unbounded"
+						processContents="lax"
+						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+					/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="bodyMetadata_type">
+		<xs:complexContent>
+			<xs:extension base="ebuttm:metadataBase_type">
+				<xs:sequence>
+					<xs:element name="authoringTechnique"
+						type="authoringTechnique_type" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:element name="transitionStyle" type="xs:string"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="facet" type="facet_type" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:any minOccurs="0" maxOccurs="unbounded"
+						processContents="lax"
+						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+					/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="divMetadata_type">
+		<xs:complexContent>
+			<xs:extension base="ebuttm:metadataBase_type">
+				<xs:sequence>
+					<xs:element name="authoringTechnique"
+						type="authoringTechnique_type" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:element name="binaryData" type="binaryData_type"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="transitionStyle" type="xs:string"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="facet" type="facet_type" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:any minOccurs="0" maxOccurs="unbounded"
+						processContents="lax"
+						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+					/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="pMetadata_type">
+		<xs:complexContent>
+			<xs:extension base="ebuttm:metadataBase_type">
+				<xs:sequence>
+					<xs:element name="authoringTechnique"
+						type="authoringTechnique_type" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:element name="transitionStyle" type="xs:string"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="facet" type="facet_type" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:any minOccurs="0" maxOccurs="unbounded"
+						processContents="lax"
+						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+					/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="spanMetadata_type">
+		<xs:complexContent>
+			<xs:extension base="ebuttm:metadataBase_type">
+				<xs:sequence>
+					<xs:element name="facet" type="facet_type" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:any minOccurs="0" maxOccurs="unbounded"
+						processContents="lax"
+						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+					/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="stylingMetadata_type">
+		<xs:complexContent>
+			<xs:extension base="ebuttm:metadataBase_type">
+				<xs:sequence>
+					<xs:element name="font" type="font_type" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:any minOccurs="0" maxOccurs="unbounded"
+						processContents="lax"
+						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+					/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
 </xs:schema>

--- a/metadata.xsd
+++ b/metadata.xsd
@@ -1,6 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" targetNamespace="http://www.w3.org/ns/ttml#metadata">
-	<xs:element name="copyright" type="xs:string" />
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+	xmlns:ttm="http://www.w3.org/ns/ttml#metadata" 
+	targetNamespace="http://www.w3.org/ns/ttml#metadata">
+	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
 	<xs:attribute name="agent" type="xs:IDREFS"/>
 	<xs:attribute name="role" type="xs:NMTOKENS"/>
+
+	<xs:element name="copyright" type="xs:string" />
+
+	<xs:element name="agent">
+		<xs:complexType>
+			<xs:sequence>
+				
+				<xs:element name="name" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType mixed="true">
+						<xs:attribute name="type">
+							<xs:simpleType>
+								<xs:restriction base="xs:token">
+									<xs:enumeration value="full"/>
+									<xs:enumeration value="family"/>
+									<xs:enumeration value="given"/>
+									<xs:enumeration value="alias"/>
+									<xs:enumeration value="other"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:attribute>
+						<xs:attribute ref="xml:id"/>
+						<xs:attribute ref="xml:lang"/>
+						<xs:attribute ref="xml:space"/>
+					</xs:complexType>
+				</xs:element>
+				
+				<xs:element name="actor" minOccurs="0" maxOccurs="1">
+					<xs:complexType>
+						<xs:attribute name="agent" use="required" type="xs:IDREF"/>
+						<xs:attribute ref="xml:id"/>
+						<xs:attribute ref="xml:lang"/>
+						<xs:attribute ref="xml:space"/>
+					</xs:complexType>
+				</xs:element>
+				
+			</xs:sequence>
+			
+			<xs:attribute name="type">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="person"/>
+						<xs:enumeration value="character"/>
+						<xs:enumeration value="group"/>
+						<xs:enumeration value="organization"/>
+						<xs:enumeration value="other"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute ref="xml:id"/>
+			<xs:attribute ref="xml:lang"/>
+			<xs:attribute ref="xml:space"/>
+		</xs:complexType>
+	</xs:element>
+	
+	<xs:element name="title" type="xs:string"/>
+	<xs:element name="desc" type="xs:string"/>
 </xs:schema>

--- a/styling.xsd
+++ b/styling.xsd
@@ -67,27 +67,15 @@ limitations under the License.
 			<xs:documentation>Background colour of a subtitle or a region.</xs:documentation>
 		</xs:annotation>
 	</xs:attribute>
-	<xs:attribute name="fontStyle">
+	<xs:attribute name="fontStyle" type="ebuttdt:fontStyleType">
 		<xs:annotation>
 			<xs:documentation>Font style that applies to glyphs.</xs:documentation>
 		</xs:annotation>
-		<xs:simpleType>
-			<xs:restriction base="xs:token">
-				<xs:enumeration value="normal"/>
-				<xs:enumeration value="italic"/>
-			</xs:restriction>
-		</xs:simpleType>
 	</xs:attribute>
-	<xs:attribute name="fontWeight">
+	<xs:attribute name="fontWeight" type="ebuttdt:fontWeightType">
 		<xs:annotation>
 			<xs:documentation>Font weight that applies to glyphs.</xs:documentation>
 		</xs:annotation>
-		<xs:simpleType>
-			<xs:restriction base="xs:token">
-				<xs:enumeration value="normal"/>
-				<xs:enumeration value="bold"/>
-			</xs:restriction>
-		</xs:simpleType>
 	</xs:attribute>
 	<xs:attribute name="textDecoration">
 		<xs:annotation>


### PR DESCRIPTION
Closes #22 by updating the metadata XSD. Rather than totally factoring it out, the metadata has been updated in place for simplicity.

In addition to updating the `ebutt_metadata.xsd` schema, to make this work some changes were needed to add styling types to `ebutt_datatypes.xsd`, to provide types needed for the metadata. It then further made sense to reference some of those types where they were used in `styling.xsd`. Some missing TTML metadata was also added into `metadata.xsd`.

Also closes #12.